### PR TITLE
Fix horizontal textarea overflow

### DIFF
--- a/src/components/settings/Settings.scss
+++ b/src/components/settings/Settings.scss
@@ -39,6 +39,7 @@
     input,
     textarea {
       width: 100%;
+      resize: vertical;
     }
 
     input[type='checkbox'] {


### PR DESCRIPTION
Currently you can resize the textarea inside the settings overview in both directions which may lead to something like this:
![image](https://user-images.githubusercontent.com/46935044/137357753-d3738f37-b71a-4ba1-8a1e-f5ac7af83bc4.png)

This PR fixes this and disallows horizontal resizing of this textarea.